### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   sonarqube:
     name: SonarQube
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/udistrital23/formatterservice/security/code-scanning/2](https://github.com/udistrital23/formatterservice/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the SonarQube job or at the root of the workflow to restrict the GITHUB_TOKEN permissions. The minimum safe setting is `contents: read`, which ensures the job can still read repository contents for scanning, but is prevented from making any changes to the contents, issues, or pull requests. Edit `.github/workflows/build.yml` by adding `permissions: contents: read` either at the root level (affecting all jobs), or under the `sonarqube` job (line 10), depending on the granularity you want. Given that only one job is shown, adding the permissions at the job level just above `runs-on` adds least disruption.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
