### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,4 +1,6 @@
 name: CI - Pruebas Nativas (Pytest + Behave)
+permissions:
+  contents: read
 
 # Se ejecuta al hacer push o pull request en la rama main
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/udistrital23/formatterservice/security/code-scanning/1](https://github.com/udistrital23/formatterservice/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow. Since no steps need write permissions to contents, we should set `contents: read` as the only permission, applying the principle of least privilege. This block can be added at the workflow root (top-level, alongside `name` and `on`) so it applies to all jobs, unless a job requires more and is given its own `permissions` block. To implement, insert the following at line 2 (between the workflow `name` and the `on` trigger).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
